### PR TITLE
force kill before close Port to avoid zombie process when not using goon in nix systems.

### DIFF
--- a/lib/porcelain/drivers/driver_common.ex
+++ b/lib/porcelain/drivers/driver_common.ex
@@ -152,6 +152,11 @@ defmodule Porcelain.Driver.Common do
         #        end
 
       {:stop, from, ref} ->
+        # force kill before close port
+        case :erlang.port_info(port, :os_pid) do
+          {:os_pid, os_pid} -> System.cmd("kill", ["#{os_pid}"])
+        end
+        
         Port.close(port)
         result = finalize_result(nil, output, error)
         send_result(output, error, result_opt, result)


### PR DESCRIPTION
I don't wanna use goon but at same time avoiding zombie process like "ping www.google.com" living even after .stop(proc). I believe 99% of the Nix systems have "kill" embedded.