### PR TITLE
Fix call to :erlang.++ function with list instead of binary

### DIFF
--- a/lib/porcelain/drivers/basic_driver.ex
+++ b/lib/porcelain/drivers/basic_driver.ex
@@ -100,7 +100,7 @@ defmodule Porcelain.Driver.Basic do
 
   defp find_executable(prog, :shell) do
     {sh, _} = Common.shell_command(prog)
-    if exe=:os.find_executable(sh) do
+    if exe=:os.find_executable(:erlang.binary_to_list(sh)) do
       {:spawn_executable, exe}
     else
       throw "Shell not found for: #{prog}"


### PR DESCRIPTION
Fix call to :erlang.++ function with list instead of binary which causes Porcelain.shell() to fail.