### PR TITLE
Use strong_rand_bytes, clean up deprecation

### DIFF
--- a/lib/porcelain/drivers/goon_driver.ex
+++ b/lib/porcelain/drivers/goon_driver.ex
@@ -229,7 +229,7 @@ defmodule Porcelain.Driver.Goon do
 
   @doc false
   def check_goon_version(path) do
-    ackstr = for << <<byte>> <- :crypto.rand_bytes(8) >>,
+    ackstr = for << <<byte>> <- :crypto.strong_rand_bytes(8) >>,
                  byte != 0, into: "", do: <<byte>>
     args = ["-proto", @proto_version, "-ack", ackstr]
     opts = {[out: {:string, ""}], []}


### PR DESCRIPTION
`crypto.rand_bytes/1` will be deprecated soon. `:crypto.strong_rand_bytes/1` is it's replacement.

```
warning: crypto:rand_bytes/1 is deprecated and will be removed in a future release; use crypto:strong_rand_bytes/1
  lib/porcelain/drivers/goon_driver.ex:234
```