### PR TITLE
Fix mix.exs warnings for Elixir 1.4-dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,10 +6,10 @@ defmodule Porcelain.Mixfile do
       app: :porcelain,
       version: "2.0.2",
       elixir: ">= 0.14.3 and < 2.0.0",
-      deps: deps,
-      description: description,
-      docs: docs,
-      package: package,
+      deps: deps(),
+      description: description(),
+      docs: docs(),
+      package: package(),
     ]
   end
 


### PR DESCRIPTION
This PR resolves these warnings when building porcelain with elixir@master:

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  [...]/deps/porcelain/mix.exs:9

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  [...]/deps/porcelain/mix.exs:10

warning: variable "docs" does not exist and is being expanded to "docs()", please use parentheses to remove the ambiguity or change the variable name
  [...]/deps/porcelain/mix.exs:11

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  [...]/deps/porcelain/mix.exs:12
```