### PR TITLE
ACK String only contains ASCII characters

### DIFF
--- a/lib/porcelain/drivers/goon_driver.ex
+++ b/lib/porcelain/drivers/goon_driver.ex
@@ -229,8 +229,7 @@ defmodule Porcelain.Driver.Goon do
 
   @doc false
   def check_goon_version(path) do
-    ackstr = for << <<byte>> <- :crypto.strong_rand_bytes(8) >>,
-                 byte != 0, into: "", do: <<byte>>
+    ackstr = Base.encode64(:crypto.strong_rand_bytes(8))
     args = ["-proto", @proto_version, "-ack", ackstr]
     opts = {[out: {:string, ""}], []}
     result = %Porcelain.Result{} = Porcelain.Driver.Basic.exec(path, args, opts)


### PR DESCRIPTION
Non-Printable characters in the ACK string provoke non-verbatim answers under Windows. Encoding the ACK String using Base 64 ensures only printable characters. Addresses Issue #18 and #20.