### PR TITLE
fix: genserver warning

### DIFF
--- a/lib/porcelain/drivers/stream_server.ex
+++ b/lib/porcelain/drivers/stream_server.ex
@@ -8,6 +8,10 @@ defmodule Porcelain.Driver.Common.StreamServer do
 
   use GenServer
 
+  def init(init_arg) do
+    {:ok, init_arg}
+  end
+
   def start() do
     GenServer.start(__MODULE__, state(chunks: :queue.new))
   end


### PR DESCRIPTION
```shell
warning: function init/1 required by behaviour GenServer is not implemented (in module Porcelain.Driver.Common.StreamServer).

We will inject a default implementation for now:

    def init(init_arg) do
      {:ok, init_arg}
    end

You can copy the implementation above or define your own that converts the arguments given to GenServer.start_link/3 to the server state.

  lib/porcelain/drivers/stream_server.ex:1: Porcelain.Driver.Common.StreamServer (module)
```