### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,29 @@
-/ebin
-/deps
-/_build
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+porcelain-*.tar
+
+# Temporary files for e.g. tests.
+/tmp/
+
+# Misc.
 /goon
-/docs/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@ Porcelain
 =========
 
 [![Build status](https://travis-ci.org/alco/porcelain.svg "Build status")](https://travis-ci.org/alco/porcelain)
-[![Hex version](https://img.shields.io/hexpm/v/porcelain.svg "Hex version")](https://hex.pm/packages/porcelain)
-![Hex downloads](https://img.shields.io/hexpm/dt/porcelain.svg "Hex downloads")
+[![Module Version](https://img.shields.io/hexpm/v/porcelain.svg)](https://hex.pm/packages/porcelain)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/porcelain/)
+[![Total Download](https://img.shields.io/hexpm/dt/porcelain.svg)](https://hex.pm/packages/porcelain)
+[![License](https://img.shields.io/hexpm/l/porcelain.svg)](https://github.com/alco/porcelain/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/alco/porcelain.svg)](https://github.com/alco/porcelain/commits/master)
+
 
 Porcelain implements a saner approach to launching and communicating with
 external OS processes from Elixir. Built on top of Erlang's ports, it provides
@@ -44,12 +48,20 @@ extensions, please refer to the [wiki][].
 Add Porcelain as a dependency to your Mix project:
 
 ```elixir
-def application do
-  [applications: [:porcelain]]
-end
-
 defp deps do
-  [{:porcelain, "~> 2.0"}]
+  [
+    {:porcelain, "~> 2.0"}
+  ]
+end
+```
+
+For Elixir before 1.4:
+
+```elixir
+def application do
+  [
+    applications: [:porcelain]
+  ]
 end
 ```
 
@@ -152,7 +164,7 @@ Porcelain.exec("grep", ["div", "-m", "4"], opts)
 # </div>
 ```
 
-The `SocketStream` module used above wraps a tcp socket in a stream. Its
+The `SocketStream` module used above wraps a TCP socket in a stream. Its
 implementation can be found in the `test/util/socket_stream.exs` file.
 
 
@@ -224,7 +236,7 @@ will search your system's `PATH` by default.
 config :porcelain, :goon_stop_timeout, <integer>
 ```
 
-This setting is used by `Porcelain.Process.stop/1`. It specifes the number of seconds `goon` will
+This setting is used by `Porcelain.Process.stop/1`. It specifies the number of seconds `goon` will
 wait for the external process to terminate before it sends `SIGKILL` to it. Default timeout is 10
 seconds.
 
@@ -259,6 +271,8 @@ particular to
   * Tim Ruffles
 
 
-## License
+## Copyright and License
 
-This software is licensed under [the MIT license](LICENSE).
+Copyright (c) 2014 Alexei Sholik
+
+Released under the MIT License, which can be found in the repository in [`LICENSE`](https://github.com/alco/porcelain/blob/master/LICENSE).

--- a/mix.exs
+++ b/mix.exs
@@ -1,52 +1,58 @@
 defmodule Porcelain.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/alco/porcelain"
+  @version "2.0.3"
+
   def project do
     [
       app: :porcelain,
-      version: "2.0.3",
+      version: @version,
       elixir: "~> 1.3",
       deps: deps(),
-      description: description(),
       docs: docs(),
-      package: package(),
+      package: package()
     ]
   end
 
   def application do
     [
       applications: [:logger, :crypto],
-      mod: {Porcelain.App, []},
+      mod: {Porcelain.App, []}
     ]
   end
 
   def docs do
     [
-      extras: [{"README.md", title: "Readme"}],
+      extras: ["CHANGELOG.md", "README.md"],
+      main: "readme",
+      source_url: @source_url,
+      formatters: ["html"]
     ]
   end
 
   defp description do
     "Porcelain implements a saner approach to launching and communicating " <>
-    "with external OS processes from Elixir. Built on top of Erlang's ports, " <>
-    "it provides richer functionality and simpler API."
+      "with external OS processes from Elixir. Built on top of Erlang's ports, " <>
+      "it provides richer functionality and simpler API."
   end
 
   defp package do
     [
+      description: description(),
       files: ["lib", "mix.exs", "README.md", "CHANGELOG.md", "LICENSE"],
       maintainers: ["Alexei Sholik"],
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/alco/porcelain",
+        "Changelog" => "https://hexdocs.pm/porcelain",
+        "GitHub" => @source_url
       }
     ]
   end
 
   defp deps do
     [
-      {:earmark, "> 0.0.0", only: :dev},
-      {:ex_doc, "> 0.0.0", only: :dev},
+      {:ex_doc, "> 0.0.0", only: :dev, runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,9 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm", "3b1dcad3067985dd8618c38399a8ee9c4e652d52a17a4aae7a6d6fc4fcc24856"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
+  "ex_doc": {:hex, :ex_doc, "0.24.1", "15673de99154f93ca7f05900e4e4155ced1ee0cd34e0caeee567900a616871a4", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "07972f17bdf7dc7b5bd76ec97b556b26178ed3f056e7ec9288eb7cea7f91cce2"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
+  "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+}


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the main source doc for this Elixir
library which leverage on latest ExDoc features.